### PR TITLE
Expose second calendar so it can be more easily toggled

### DIFF
--- a/JTCalendar/Views/JTCalendarMenuView.h
+++ b/JTCalendar/Views/JTCalendarMenuView.h
@@ -17,6 +17,13 @@
 
 @property (nonatomic, readonly) UIScrollView *scrollView;
 
+/**
+ Provides an external reference to the label container view that displays the
+ second month's name when the calendar is able to show two months side by side
+ (eg. on the iPad in landscape orientation)
+ */
+@property (nonatomic, readonly) UIView *secondMonthLabelView;
+
 /*!
  * Must be call if override the class
  */

--- a/JTCalendar/Views/JTCalendarMenuView.m
+++ b/JTCalendar/Views/JTCalendarMenuView.m
@@ -21,7 +21,6 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     
     UIView *_leftView;
     UIView *_centerView;
-    UIView *_centerSecondMonthView;
     UIView *_rightView;
     UIView *_reuseView;
     
@@ -120,7 +119,7 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
         _reuseView.frame = CGRectMake(_reuseView.frame.origin.x, 0, _scrollView.frame.size.width, size.height);
         
         if (self.manager.showSecondMonth) {
-            _centerSecondMonthView.frame = CGRectMake(_centerView.frame.origin.x, 0, _scrollView.frame.size.width, size.height);
+            _secondMonthLabelView.frame = CGRectMake(_centerView.frame.origin.x, 0, _scrollView.frame.size.width, size.height);
         }
     }
 }
@@ -173,7 +172,7 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     _leftView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
     _centerView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
     if (self.manager.showSecondMonth) {
-        _centerSecondMonthView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
+        _secondMonthLabelView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
     }
     _rightView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
     _reuseView.frame = CGRectMake(size.width * viewCount++, 0, size.width, size.height);
@@ -205,8 +204,8 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
         [_scrollView addSubview:_centerView];
         
         if (self.manager.showSecondMonth) {
-            _centerSecondMonthView = [_manager.delegateManager buildMenuItemView];
-            [_scrollView addSubview:_centerSecondMonthView];
+            _secondMonthLabelView = [_manager.delegateManager buildMenuItemView];
+            [_scrollView addSubview:_secondMonthLabelView];
         }
         
         _rightView = [_manager.delegateManager buildMenuItemView];
@@ -222,7 +221,7 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     [_manager.delegateManager prepareMenuItemView:_reuseView date:reuseDate];
     
     if (self.manager.showSecondMonth) {
-        [_manager.delegateManager prepareMenuItemView:_centerSecondMonthView date:currentSecondMonthDate];
+        [_manager.delegateManager prepareMenuItemView:_secondMonthLabelView date:currentSecondMonthDate];
     }
     
     BOOL haveLeftPage = [_manager.delegateManager canDisplayPageWithDate:previousDate];

--- a/JTCalendar/Views/JTHorizontalCalendarView.h
+++ b/JTCalendar/Views/JTHorizontalCalendarView.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #import "JTContent.h"
+#import "JTCalendarPage.h"
 
 typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     JTCalendarPageModeFull,
@@ -22,6 +23,13 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
 @property (assign, nonatomic) JTCalendarPageMode pageMode;
 
 @property (nonatomic) NSDate *date;
+
+/**
+ Provides an external reference to the month container view that displays the
+ second month when the calendar is able to show two months side by side
+ (eg. on the iPad in landscape orientation)
+ */
+@property (nonatomic, readonly) UIView<JTCalendarPage> *centerSecondMonthView;
 
 /*!
  * Must be call if override the class

--- a/JTCalendar/Views/JTHorizontalCalendarView.m
+++ b/JTCalendar/Views/JTHorizontalCalendarView.m
@@ -14,7 +14,6 @@
     
     UIView<JTCalendarPage> *_leftView;
     UIView<JTCalendarPage> *_centerView;
-    UIView<JTCalendarPage> *_centerSecondMonthView; //for use with two month view
     UIView<JTCalendarPage> *_rightView;
     UIView<JTCalendarPage> *_reuseView;
 }


### PR DESCRIPTION
These changes expose the various control elements associated with displaying the second calendar that would appear on iPad.

Exposing this was needed in order to toggle their appearance in case certain situations on the iPad displayed the calendar within a view that was too narrow to display two months.