### PR TITLE
BugFix: Crash in prepareMenuItemView when a nil NSDate is passed in.

### DIFF
--- a/JTCalendar/Managers/JTCalendarDelegateManager.m
+++ b/JTCalendar/Managers/JTCalendarDelegateManager.m
@@ -32,14 +32,18 @@
 
 - (void)prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date
 {
-    if(_manager.delegate && [_manager.delegate respondsToSelector:@selector(calendar:prepareMenuItemView:date:)]){
-        [_manager.delegate calendar:self.manager prepareMenuItemView:menuItemView date:date];
+    if(menuItemView == nil || [menuItemView isEqual:[NSNull null]]) {
         return;
     }
     
     NSString *text = nil;
     
-    if(date){
+    if(date != nil && ![date isEqual:[NSNull null]]){
+        if(_manager.delegate && [_manager.delegate respondsToSelector:@selector(calendar:prepareMenuItemView:date:)]){
+            [_manager.delegate calendar:self.manager prepareMenuItemView:menuItemView date:date];
+            return;
+        }
+        
         NSCalendar *calendar = _manager.dateHelper.calendar;
         NSDateComponents *comps = [calendar components:NSCalendarUnitYear|NSCalendarUnitMonth fromDate:date];
         NSInteger currentMonthIndex = comps.month;
@@ -48,7 +52,7 @@
         if(!dateFormatter){
             dateFormatter = [_manager.dateHelper createDateFormatter];
         }
-
+        
         dateFormatter.timeZone = _manager.dateHelper.calendar.timeZone;
         dateFormatter.locale = _manager.dateHelper.calendar.locale;
         
@@ -58,7 +62,7 @@
         
         text = [[dateFormatter standaloneMonthSymbols][currentMonthIndex - 1] capitalizedString];
     }
-        
+    
     [(UILabel *)menuItemView setText:text];
 }
 


### PR DESCRIPTION
We keep hitting a crash in our app store build where the delegate method `calendar:prepareMenuItemView:date:` of JTCalendarDelegate is called. I believe what is happening is that either a nil pointer for either `menuItemView` or` date` is being passed in, or either of those two pointers is actually `NSNULL`. In both cases, the Swift runtime would not like that. This should check for that condition.

Please note, I have not been able to reproduce this locally, but based on the crash log it's the only explanation I can think of that would cause the crash.

Go [here](https://appcenter.ms/users/jkhunkhun-xaqr/apps/WestJet-AppStore/crashes/errors/555524086u/overview) to see the original crash report.